### PR TITLE
Add index to property rules to prevent conflict with system rules

### DIFF
--- a/tu154b-set.xml
+++ b/tu154b-set.xml
@@ -477,7 +477,7 @@
   </multiplay>
 
   <systems>
-    <property-rule>
+    <property-rule n="100">
       <path>Aircraft/tu154b/Systems/property-rules.xml</path>
     </property-rule>
   </systems>


### PR DESCRIPTION
Without an index, this property rule was overriding the METAR interpolator
which meant basic weather was not being translated from METAR. The symptom
was no clouds in basic weather with the TU154B.

See http://forum.flightgear.org/viewtopic.php?f=25&t=27573