### PR TITLE
Fix RSBN handle_2 knob to allow full freq decimal range (0.000-0.995)

### DIFF
--- a/Instruments-3d/rsbn/rsbn.xml
+++ b/Instruments-3d/rsbn/rsbn.xml
@@ -61,7 +61,7 @@
   <property>tu154/instrumentation/rsbn/handle-2</property>
   <interpolation>
     <entry><ind>	0.0</ind>	<dep>	-60.0</dep></entry>
-    <entry><ind>	9.0</ind>	<dep>	210.0</dep></entry>
+    <entry><ind>	9.95</ind>	<dep>	235.65</dep></entry>
   </interpolation>
   <center>
     <x-m>0.0</x-m>

--- a/Nasal/instruments.nas
+++ b/Nasal/instruments.nas
@@ -1794,7 +1794,7 @@ if( getprop("tu154/instrumentation/rsbn/mode") == 0)
   }
 else {
   handle = handle + step/20.0;
-  if( handle > 9.0 ) handle = 9.0;
+  if( handle > 9.95 ) handle = 9.95;
   if( handle < 0.0 ) handle = 0.0;
   var freq = getprop("tu154/instrumentation/rsbn/frequency" );
   if( freq == nil ) freq = 108.0;


### PR DESCRIPTION
When using RSBN in VOR-DME mode it is not possible to rotate the MHz-fraction knob past the 0.9 mark, hence it is not possible to use some of the navaids as RSBN correction sources - eg. AMS VOR-DME (Amsterdam Schiphol) which has frequency of 113.95 or GRM (Oslo Gardermoen) which is at 115.95.

This trivial fix allows handle_2 to rotate past the 0.9 mark up to 0.995.
